### PR TITLE
Validate token endpoint

### DIFF
--- a/apps/auth-service/src/modules/auth/application/mappers/auth.mapper.ts
+++ b/apps/auth-service/src/modules/auth/application/mappers/auth.mapper.ts
@@ -28,10 +28,7 @@ export class AuthMapper {
   }
 
   static toValidateTokenResponse(valid: boolean, userId: number): ValidateTokenResponse {
-    return {
-      valid,
-      userId,
-    };
+    return {valid};
   }
 
   static toForgotPasswordResponse(success: boolean, message: string): ForgotPasswordResponse {

--- a/apps/auth-service/src/modules/auth/application/use-cases/validate-token.use-case.ts
+++ b/apps/auth-service/src/modules/auth/application/use-cases/validate-token.use-case.ts
@@ -17,24 +17,25 @@ export class ValidateTokenUseCase {
   async execute(token: string): Promise<ValidateTokenUseCaseResponse> {
     const userToken = await this.userTokenRepository.findByToken(token);
 
+    // We default to NOT valid and throw NOT_FOUND for any invalid case to avoid leaking information
     if (!userToken) {
       throw new RpcException({
         code: status.NOT_FOUND,
-        message: 'Token not found',
+        message: 'Token not found, expired or already used',
       });
     }
 
     if (userToken.usedAt) {
       throw new RpcException({
-        code: status.FAILED_PRECONDITION,
-        message: 'Token has already been used',
+        code: status.NOT_FOUND,
+        message: 'Token not found, expired or already used',
       });
     }
 
     if (userToken.expiresAt < new Date()) {
       throw new RpcException({
-        code: status.DEADLINE_EXCEEDED,
-        message: 'Token has expired',
+        code: status.NOT_FOUND,
+        message: 'Token not found, expired or already used',
       });
     }
 

--- a/apps/gateway/src/modules/auth/auth.controller.ts
+++ b/apps/gateway/src/modules/auth/auth.controller.ts
@@ -7,6 +7,7 @@ import {
   UseGuards,
   Req,
   Put,
+  Query,
 } from '@nestjs/common';
 import {
   ApiTags,
@@ -14,6 +15,7 @@ import {
   ApiResponse,
   ApiSecurity,
   ApiBody,
+  ApiQuery,
 } from '@nestjs/swagger';
 import { Response, Request } from 'express';
 import { ConfigService } from '@nestjs/config';
@@ -152,6 +154,16 @@ export class AuthController {
       dto.oldPassword,
       dto.newPassword,
     );
+  }
+
+  @Public()
+  @ApiOperation({ summary: 'Verify if a token is still valid. You can check any type of system token!' })
+  @ApiResponse({ status: 200, description: 'Token is valid' })
+  @ApiResponse({ status: 404, description: 'Token not found, expired or already used' })
+  @ApiQuery({ name: 'token', required: true, description: 'The token to validate' })
+  @Get('validate-token')
+  async validateToken(@Query('token') token: string) {
+    return this.authService.validateToken(token);
   }
 
   /**

--- a/apps/gateway/src/modules/auth/auth.service.ts
+++ b/apps/gateway/src/modules/auth/auth.service.ts
@@ -50,6 +50,12 @@ export class AuthService implements OnModuleInit {
     );
   }
 
+  async validateToken(token: string): Promise<ValidateTokenResponse> {
+    return firstValueFrom(
+      this.authService.validateToken({ token } as ValidateTokenRequest),
+    );
+  }
+
   async getUser(id: number): Promise<User> {
     return firstValueFrom(this.authService.getUser({ id } as GetUserRequest));
   }

--- a/libs/common/src/protos/auth.proto
+++ b/libs/common/src/protos/auth.proto
@@ -98,7 +98,6 @@ message ValidateTokenRequest {
 // The response message for a token validation.
 message ValidateTokenResponse {
   bool valid = 1;
-  int32 userId = 2;
 }
 
 message ActivateUserRequest {


### PR DESCRIPTION
In this PR, I'm adding the validate-token endpoint. This allows the back-end application to validate any type of token in the system. It's a secure endpoint, it does not returns any unnecessary information except if the token is `valid` or not