### PR TITLE
[86e0fq3e1]: fix prisma seed script

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,6 +95,6 @@
     "typescript-eslint": "^8.20.0"
   },
   "prisma": {
-    "seed": "node dist/apps/auth-service/prisma/seed.js 2>/dev/null || ts-node apps/auth-service/prisma/seed.ts"
+    "seed": "ts-node apps/auth-service/prisma/seed.ts"
   }
 }


### PR DESCRIPTION
We replaced the previous Prisma seed script `node dist/apps/auth-service/prisma/seed.js 2>/dev/null` with a direct TypeScript execution `ts-node apps/auth-service/prisma/seed.ts` to avoid missing dist-artifact failures on dev restarts.