### PR TITLE
Update email template text for notification service

### DIFF
--- a/apps/notification-service/src/infrastructure/email/templates/iris_project_approved.html
+++ b/apps/notification-service/src/infrastructure/email/templates/iris_project_approved.html
@@ -125,7 +125,7 @@ subject: Iris | Proyecto aprobado
       </p>
 
       <p>
-        Estamos muy emocionados por tu participación. Tu propuesta cumple <br/>con todos los criterios establecidos por la Decanatura de Ingenierías.
+        Estamos muy emocionados por tu participación. Tu propuesta cumple <br/>con todos los criterios establecidos.
       </p>
 
       <p>

--- a/apps/notification-service/src/infrastructure/email/templates/iris_project_submitted.html
+++ b/apps/notification-service/src/infrastructure/email/templates/iris_project_submitted.html
@@ -120,7 +120,7 @@ subject: Iris | ¡Inscripción del Proyecto Exitosa!
       <p>
         Tu proyecto <strong>{{ projectName }}</strong> ha sido creado
         correctamente y se encuentra actualmente
-        <strong>en revisión por Decanatura</strong>.
+        <strong>en revisión por el área administrativa. </strong>.
       </p>
 
       <p>


### PR DESCRIPTION

This pull request updates the notification email templates to use more accurate and neutral language regarding project approval and review processes. The changes ensure that references to specific departments are generalized or removed, improving clarity for recipients.

**Email template language updates:**

* In `iris_project_submitted.html`, changed the review status message to state that the project is under review by the administrative area instead of specifically by "Decanatura".
* In `iris_project_approved.html`, removed the mention of "Decanatura de Ingenierías" from the approval criteria, making the message more general.