### PR TITLE
[86e0rnwzd]: added new use case for checking repeated user submissions

### DIFF
--- a/apps/gateway/src/modules/events/events.controller.ts
+++ b/apps/gateway/src/modules/events/events.controller.ts
@@ -112,6 +112,7 @@ export class EventsController {
    * Returns events with user's role information
    */
   @Get('my-events')
+  @ApiBearerAuth()
   @ApiOperation({
     summary: 'List my events',
     description: 'Get a paginated list of events where the authenticated user is a member. Includes role information.',

--- a/apps/gateway/src/modules/events/events.controller.ts
+++ b/apps/gateway/src/modules/events/events.controller.ts
@@ -112,7 +112,6 @@ export class EventsController {
    * Returns events with user's role information
    */
   @Get('my-events')
-  @ApiBearerAuth()
   @ApiOperation({
     summary: 'List my events',
     description: 'Get a paginated list of events where the authenticated user is a member. Includes role information.',

--- a/apps/gateway/src/modules/projects/projects.controller.ts
+++ b/apps/gateway/src/modules/projects/projects.controller.ts
@@ -80,6 +80,10 @@ export class ProjectsController {
     description: 'Invalid input data, file too large, or too many files',
   })
   @ApiResponse({
+    status: 409,
+    description: 'One or more of the project participants already have an existing project in this event.'
+  })
+  @ApiResponse({
     status: 413,
     description: 'File size exceeds 5MB limit',
   })

--- a/apps/project-service/src/modules/projects/application/use-cases/check-active-submission-by-emails.uc.ts
+++ b/apps/project-service/src/modules/projects/application/use-cases/check-active-submission-by-emails.uc.ts
@@ -1,0 +1,33 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from '../../../../common/prisma/prisma.service';
+
+/**
+ * Checks whether any of the given emails already has a pending project participant
+ * in the same event for a project whose state != REJECTED.
+ */
+@Injectable()
+export class CheckActiveSubmissionByEmailsUC {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async execute(input: { eventId: number; emails: string[] }): Promise<{ hasConflict: boolean; conflictEmails: string[] }> {
+    const normalized = (input.emails ?? [])
+      .map((e) => String(e ?? '').trim().toLowerCase())
+      .filter(Boolean);
+
+    if (!normalized.length) return { hasConflict: false, conflictEmails: [] };
+
+    const rows = await this.prisma.pendingProjectParticipant.findMany({
+      where: {
+        email: { in: normalized },
+        project: {
+          eventId: input.eventId,
+          state: { not: 'REJECTED' },
+        },
+      },
+      select: { email: true },
+    });
+
+    const conflictEmails: string[] = Array.from(new Set(rows.map((r: { email: string; }) => String(r.email))));
+    return { hasConflict: conflictEmails.length > 0, conflictEmails };
+  }
+}

--- a/apps/project-service/src/modules/projects/interface/grpc/projects.controller.ts
+++ b/apps/project-service/src/modules/projects/interface/grpc/projects.controller.ts
@@ -1,5 +1,5 @@
 import { Controller, Inject, Injectable } from '@nestjs/common';
-import { GrpcMethod } from '@nestjs/microservices';
+import { GrpcMethod, RpcException } from '@nestjs/microservices';
 import { CreateProjectUC } from '../../application/use-cases/create-project.uc';
 import { ListProjectsByEventUC } from '../../application/use-cases/list-projects-by-event.uc';
 import { GetProjectUC } from '../../application/use-cases/get-project.uc';
@@ -24,9 +24,11 @@ import { ListProjectsByFilterDTO } from '../../application/dto/list-projects.dto
 import { UpdateProjectDocumentUC } from '../../application/use-cases/update-document.uc';
 import { RequestChangesProjectUC } from '../../application/use-cases/request-changes-project.uc';
 import { GetMyProjectByEventUC } from '../../application/use-cases/get-my-project-by-event.uc';
+import { CheckActiveSubmissionByEmailsUC } from '../../application/use-cases/check-active-submission-by-emails.uc';
 import { ClientGrpc } from '@nestjs/microservices';
 import { INVITATION_SERVICE_NAME } from '@app/common/generated/invitation';
 import { lastValueFrom } from 'rxjs';
+import { status } from '@grpc/grpc-js';
 
 interface InvitationGrpcService {
   CreateInvitation(data: {
@@ -69,6 +71,7 @@ export class ProjectsController {
     private readonly listProjectsForReviewUC: ListProjectsForReviewUC,  
     private readonly updateProjectDocumentUC: UpdateProjectDocumentUC,
     private readonly getMyProjectByEventUC: GetMyProjectByEventUC,
+    private readonly checkActiveSubmissionByEmailsUC: CheckActiveSubmissionByEmailsUC,
     @Inject(INVITATION_SERVICE_NAME) private readonly client: ClientGrpc,
   ) {}
 
@@ -232,6 +235,14 @@ async listPendingParticipantsRpc(req: { projectId: number }) {
 
 @GrpcMethod('ProjectsService', 'CreateProjectWithPendingParticipants')
 async createProjectWithPendingParticipantsRpc(req: any) {
+  if (req.participants && req.participants.length > 0) {
+    const emails = req.participants.map((p: any) => p.email);
+    const { hasConflict, conflictEmails } = await this.checkActiveSubmissionByEmailsUC.execute({ eventId: req.eventId, emails });
+    if (hasConflict) {
+      throw new RpcException({ code: status.ALREADY_EXISTS, message: `Conflicting active submissions found for emails: ${conflictEmails.join(', ')}` });
+    }
+  }
+
   try {
     const project = await this.createProject.execute({
       eventId: req.eventId,

--- a/apps/project-service/src/modules/projects/projects.module.ts
+++ b/apps/project-service/src/modules/projects/projects.module.ts
@@ -31,6 +31,7 @@ import { NotificationServiceAdapter } from './infrastructure/grpc-client/notific
 import { NotificateStudentUC } from './application/use-cases/notificate-student.uc';
 import { ListProjectsForReviewUC } from './application/use-cases/list-projects-for-review.uc';
 import { UpdateProjectDocumentUC } from './application/use-cases/update-document.uc';
+import { CheckActiveSubmissionByEmailsUC } from './application/use-cases/check-active-submission-by-emails.uc';
 
 @Module({
   controllers: [ProjectsController],
@@ -50,7 +51,7 @@ import { UpdateProjectDocumentUC } from './application/use-cases/update-document
     ReassignProjectJurorUC,ListProjectJurorsUC, AddParticipantUC,
     ListParticipantsUC,AddPendingParticipantUC,ListPendingParticipantsUC,
     ListProjectsAssignedToJurorUC,ListProjectsForReviewUC,
-    NotificateStudentUC,UpdateProjectDocumentUC, RequestChangesProjectUC,
+    NotificateStudentUC,UpdateProjectDocumentUC, RequestChangesProjectUC, CheckActiveSubmissionByEmailsUC,
     {
       provide: NOTIFICATION_SERVICE_PORT,
       useExisting: NotificationServiceAdapter,


### PR DESCRIPTION
This PR adds a new use case to the project service to check for duplicate user emails on project submissions. Before, users could submit as many projects as they wanted on any event. Now, they can only do so if they don't have an existing, non `REJECTED` project in said event. If the check fails, it returns an error with status code 409 to the frontend.