### PR TITLE
[CU-86e0vq5v7]: feat(events) include awards and registration details

### DIFF
--- a/apps/gateway/src/modules/events/events.service.ts
+++ b/apps/gateway/src/modules/events/events.service.ts
@@ -181,6 +181,55 @@ export class EventService implements OnModuleInit {
         return currentPage < totalPages ? String(currentPage + 1) : '';
     }
 
+    private async getEventCatalogData(eventId: number) {
+        const [categoriesResponse, detailsResponse] = await Promise.all([
+            this.listCategoriesByEvent(eventId, {
+                eventId,
+                page: 1,
+                limit: 1000,
+            }),
+            this.listEventInscriptionDetails({
+                eventId,
+                page: 1,
+                limit: 1000,
+            }),
+        ]);
+
+        const categories = categoriesResponse.categories ?? [];
+        const awardsByCategory = await Promise.all(
+            categories.map((category) =>
+                this.listCategoryAwards({
+                    categoryId: category.id,
+                    page: 1,
+                    limit: 1000,
+                }),
+            ),
+        );
+
+        return {
+            category: categories[0] ?? null,
+            categories,
+            awards: awardsByCategory.flatMap((item) => item.awards ?? []),
+            specificInscriptionDetails: detailsResponse.details ?? [],
+        };
+    }
+
+    private async enrichEventWithCatalogData<T extends { id: number }>(event: T) {
+        const catalogData = await this.getEventCatalogData(event.id);
+        return {
+            ...event,
+            ...catalogData,
+        };
+    }
+
+    private async enrichEventsWithCatalogData<T extends { id: number }>(events: T[]) {
+        if (!events || events.length === 0) {
+            return [];
+        }
+
+        return Promise.all(events.map((event) => this.enrichEventWithCatalogData(event)));
+    }
+
     async create(createEventDTO: CreateEventDTO): Promise<CreateEventResponse> {
         const {
             category,
@@ -266,7 +315,8 @@ export class EventService implements OnModuleInit {
         if (response.event) {
             const statuses = await this.getAndCacheStatuses();
             const enrichedEvent = this.enrichSingleEventWithStatus(response.event, statuses);
-            return { event: enrichedEvent as EventProto };
+            const enrichedEventWithCatalog = await this.enrichEventWithCatalogData(enrichedEvent);
+            return { event: enrichedEventWithCatalog as any };
         }
 
         return response;
@@ -613,9 +663,11 @@ export class EventService implements OnModuleInit {
             };
         });
 
+        const enrichedEventsWithCatalog = await this.enrichEventsWithCatalogData(enrichedEvents);
+
         return {
             ...response,
-            events: enrichedEvents as any,
+            events: enrichedEventsWithCatalog as any,
         };
     }
 
@@ -630,10 +682,11 @@ export class EventService implements OnModuleInit {
 
         const statuses = await this.getAndCacheStatuses();
         const enrichedEvents = this.enrichEventsWithStatus(response.events, statuses);
+        const enrichedEventsWithCatalog = await this.enrichEventsWithCatalogData(enrichedEvents);
 
         return {
             ...response,
-            events: enrichedEvents as EventProto[],
+            events: enrichedEventsWithCatalog as any,
         };
     }
 


### PR DESCRIPTION
The Gateway layer was adjusted so event responses include catalog information related to each event, instead of returning only the base Event object. With this change, event read endpoints now return embedded awards and specific inscription details per event.

**Changes Made**
1. Added per-event catalog enrichment in events.service.ts:
- New method to load catalog data by `eventId`:
- event categories
- awards from all categories
- event `specificInscriptionDetails`

2. Added bulk enrichment for event lists in events.service.ts:
- Method to apply the enrichment to an array of events using `Promise.all`.

3. Applied that enrichment to the main read operations in events.service.ts:
- `get(...)`
- `listEvents(...)`
- `listMyEvents(...)`

4. Extended the enriched payload to include `category` (singular) in addition to `categories` in events.service.ts:
- `category`: first category found, or `null`
- `categories`: full array

**Functional Impact**
1. Event GET/LIST responses now include, for each event:
- `category`
- `categories`
- `awards`
- `specificInscriptionDetails`

2. This covers the Gateway endpoints that depend on `get/list`, including both public and authenticated event flows.

3. The frontend no longer needs separate calls to fetch awards and specific details for each event, although it still can if needed.
