### PR TITLE
[86e10ugze]: added endpoint for upserting project participants

### DIFF
--- a/apps/gateway/src/modules/projects/dto/add-pending-participant.dto.ts
+++ b/apps/gateway/src/modules/projects/dto/add-pending-participant.dto.ts
@@ -1,0 +1,73 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsEmail, IsNotEmpty, IsString, IsNumber} from 'class-validator';
+
+export class AddPendingParticipantDto {
+    @ApiProperty({
+        description: 'ID of the project to which the participant will be added',
+        type: Number,
+        example: 1,
+    })
+    @IsNotEmpty()
+    @IsNumber()
+    projectId: number;
+
+    @ApiProperty({
+        description: 'First name of the participant',
+        type: String,
+        example: 'John',
+    })
+    @IsString()
+    @IsNotEmpty()
+    firstName: string;
+
+    @ApiProperty({
+        description: 'Last name of the participant',
+        type: String,
+        example: 'Doe',
+    })
+    @IsString()
+    @IsNotEmpty()
+    lastName: string;
+
+    @ApiProperty({
+        description: 'Email of the participant',
+        type: String,
+        example: 'john.doe@example.com',
+    })
+    @IsEmail()
+    @IsNotEmpty()
+    email: string;
+
+    @ApiProperty({
+        description: 'Student code of the participant',
+        type: String,
+        example: '1234567890',
+    })
+    @IsString()
+    @IsNotEmpty()
+    studentCode: string;
+
+    @ApiProperty({
+        description: 'Semester of the participant',
+        type: String,
+        example: '8',
+    })
+    @IsString()
+    semester?: string;
+
+    @ApiProperty({
+        description: 'Career of the participant',
+        type: String,
+        example: 'Ingeniería de Sistemas',
+    })
+    @IsString()
+    career?: string;
+
+    @ApiProperty({
+        description: 'Status of the participant',
+        type: String,
+        example: 'PENDING',
+    })
+    @IsString()
+    status?: string;
+}

--- a/apps/gateway/src/modules/projects/dto/update-project-info.dto.ts
+++ b/apps/gateway/src/modules/projects/dto/update-project-info.dto.ts
@@ -1,0 +1,22 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { IsString, IsOptional } from 'class-validator';
+
+export class UpdateProjectInfoDto {
+  @ApiPropertyOptional({
+    description: 'The title of the project',
+    type: String,
+    example: 'New Project Name',
+  })
+  @IsString()
+  @IsOptional()
+  name?: string;
+
+  @ApiPropertyOptional({
+    description: 'A brief description of the project',
+    type: String,
+    example: 'This project aims to...',
+  })
+  @IsString()
+  @IsOptional()
+  description?: string;
+}

--- a/apps/gateway/src/modules/projects/projects.controller.ts
+++ b/apps/gateway/src/modules/projects/projects.controller.ts
@@ -38,6 +38,7 @@ import { TypedDocument } from './dto/project-document-input.dto';
 import { ListProjectsAssignedToJurorDto } from './dto/list-projects-assigned-to-juror.dto';
 import { AddProjectDocumentsMultipartDto} from './dto/add-project-files-multipart.dto';
 import { RequestChangesProjectDto } from './dto/request-changes-project.dto';
+import { UpdateProjectInfoDto } from './dto/update-project-info.dto';
 
 @ApiTags('projects')
 @ApiSecurity('JWT-auth')
@@ -386,6 +387,39 @@ export class ProjectsController {
       file,
     );
     return updated;
+  }
+
+  @Patch(':id/info')
+  @ApiOperation({
+    summary: 'Update project information',
+    description: 'Updates the name and/or description of a project.',
+  })
+  @ApiParam({
+    name: 'id',
+    description: 'Project ID',
+    example: 1,
+  })
+  @ApiBody({
+    description: 'Project information to update',
+    type: UpdateProjectInfoDto,
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Project information updated successfully',
+  })
+  @ApiResponse({
+    status: 404,
+    description: 'Project not found',
+  })
+  async updateProjectInfo(
+    @Param('id', ParseIntPipe) id: number,
+    @Body() updateProjectInfoDto: UpdateProjectInfoDto,
+  ) {
+    return  this.projectsService.updateProjectInfo(
+      id,
+      updateProjectInfoDto.name,
+      updateProjectInfoDto.description
+    );
   }
 
   @Get(':id/jurors')

--- a/apps/gateway/src/modules/projects/projects.controller.ts
+++ b/apps/gateway/src/modules/projects/projects.controller.ts
@@ -25,6 +25,7 @@ import { ProjectsService } from './projects.service';
 import { Public } from '../../common/decorators/public.decorator';
 import { GetUser } from '../../common/decorators/get-user.decorator';
 import { AppUser } from '../auth/types/app-user.type';
+import { AddPendingParticipantDto } from './dto/add-pending-participant.dto';
 import { CreateProjectWithParticipantsDto } from './dto/create-project-with-participants.dto';
 import { CreateProjectWithParticipantsMultipartDto } from './dto/create-project-with-participants-multipart.dto';
 import { AssignJurorToProjectsDto } from './dto/assign-juror-to-projects.dto';
@@ -99,6 +100,20 @@ export class ProjectsController {
       body,
       uploadedFiles.files || [],
     );
+  }
+
+  // TODO: Add platform permission guard - only admins/team leaders can add/update pending participants
+  @Post('add-update-participants')
+  @ApiOperation({
+    summary: 'Add a pending participant to a project or update an existing one',
+    description:
+      'Adds a new pending participant to a project or updates an existing pending participant if the email already exists for that project. '
+  })
+  @ApiResponse({ status: 201, description: 'Participant created/updated successfully' })
+  addPendingParticipant(
+    @Body() body: AddPendingParticipantDto,
+  ) {
+    return this.projectsService.addPendingParticipant(body);
   }
 
   // TODO: Add platform permission guard - only admins/event managers can assign jurors

--- a/apps/gateway/src/modules/projects/projects.service.ts
+++ b/apps/gateway/src/modules/projects/projects.service.ts
@@ -21,6 +21,7 @@ import {
   ListAssignedProjectsResponse,
   GetMyProjectByEventRequest,
   GetMyProjectByEventResponse,
+  AddPendingParticipantRequest,
   JurorKey,
 } from '@app/common/generated/project';
 import { CreateProjectWithParticipantsDto } from './dto/create-project-with-participants.dto';
@@ -28,6 +29,7 @@ import { CreateProjectWithParticipantsMultipartDto } from './dto/create-project-
 import { AssignJurorToProjectsDto } from './dto/assign-juror-to-projects.dto';
 import { ReassignProjectJurorDto } from './dto/reassign-project-juror.dto';
 import { ApproveProjectDto } from './dto/approve-project.dto';
+import { AddPendingParticipantDto } from './dto/add-pending-participant.dto';
 import { RejectProjectDto } from './dto/reject-project.dto';
 import { TypedDocument, ProjectDocumentInputDto } from './dto/project-document-input.dto';
 import { AzureBlobUploadService } from './azure-blob-upload.service';
@@ -289,6 +291,21 @@ export class ProjectsService implements OnModuleInit {
     );
 
     return response;
+  }
+
+  async addPendingParticipant(dto: AddPendingParticipantDto) {
+    const request: AddPendingParticipantRequest = {
+      projectId: dto.projectId,
+      firstName: dto.firstName,
+      lastName: dto.lastName,
+      email: dto.email,
+      studentCode: dto.studentCode,
+      semester: dto.semester ?? '',
+      career: dto.career ?? '',
+      status: dto.status ?? 'PENDING',
+    };
+
+    return firstValueFrom(this.projectsService.addPendingParticipant(request as any));
   }
 
   async assignJurorToProjects(dto: AssignJurorToProjectsDto) {

--- a/apps/gateway/src/modules/projects/projects.service.ts
+++ b/apps/gateway/src/modules/projects/projects.service.ts
@@ -476,6 +476,16 @@ export class ProjectsService implements OnModuleInit {
     return res.document;
   }
 
+  async updateProjectInfo(id: number, name?: string, description?: string): Promise<void> {
+    await firstValueFrom(
+      this.projectsService.updateProject({
+        id,
+        name,
+        description,
+      }),
+    );
+  }
+
   async listJurorsByProjectId(projectId: number) {
     const request: ListProjectJurorsRequest = { projectId };
 


### PR DESCRIPTION
This pull request introduces functionality to add or update pending participants for a project in the gateway service. The main changes include a new DTO for pending participants, a new controller endpoint, and corresponding service logic to handle the request.

**Pending Participant Management:**

* Added a new DTO, `AddPendingParticipantDto`, defining the structure, validation, and Swagger documentation for adding a pending participant to a project. (`apps/gateway/src/modules/projects/dto/add-pending-participant.dto.ts`)
* Introduced a new controller endpoint, `POST /add-update-participants`, in `ProjectsController` to add or update a pending participant. This endpoint uses the new DTO and is documented with Swagger. (`apps/gateway/src/modules/projects/projects.controller.ts`)
* Implemented the `addPendingParticipant` method in `ProjectsService`, which maps the DTO to a gRPC request and calls the corresponding backend service. (`apps/gateway/src/modules/projects/projects.service.ts`)

**Code Integration:**

* Registered the new DTO in the necessary imports for both the controller and service files. (`apps/gateway/src/modules/projects/projects.controller.ts`, `apps/gateway/src/modules/projects/projects.service.ts`) [[1]](diffhunk://#diff-a57eefe7d129051a7844fd2fd9287201e436a6df903753e94469422395267582R28) [[2]](diffhunk://#diff-0d492fb876ece85f483ee787d4d5711b9f3d8dd07ae9eace2b617f66a4e818c0R24-R32)