### PR TITLE
Fix: Allow project registration on event deadline day

### DIFF
--- a/apps/auth-service/Dockerfile
+++ b/apps/auth-service/Dockerfile
@@ -5,8 +5,9 @@ WORKDIR /app
 RUN apk add --no-cache protobuf-dev && \
   npm install -g pnpm
 
-COPY package.json pnpm-lock.yaml ./
-RUN pnpm install --frozen-lockfile
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+RUN npm pkg delete scripts.prepare && \
+  pnpm install --frozen-lockfile
 
 COPY . .
 
@@ -42,7 +43,7 @@ ENV HUSKY=0
 RUN apk add --no-cache dumb-init openssl && \
   npm install -g pnpm prisma@6.16.2
 
-COPY package.json pnpm-lock.yaml ./
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 RUN npm pkg delete scripts.prepare && \
     pnpm install --prod --frozen-lockfile
 

--- a/apps/evaluation-service/Dockerfile
+++ b/apps/evaluation-service/Dockerfile
@@ -5,8 +5,9 @@ WORKDIR /app
 RUN apk add --no-cache protobuf-dev && \
   npm install -g pnpm
 
-COPY package.json pnpm-lock.yaml ./
-RUN pnpm install --frozen-lockfile
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+RUN npm pkg delete scripts.prepare && \
+  pnpm install --frozen-lockfile
 
 COPY . .
 
@@ -37,7 +38,7 @@ ENV HUSKY=0
 RUN apk add --no-cache dumb-init openssl && \
   npm install -g pnpm prisma@6.16.2
 
-COPY package.json pnpm-lock.yaml ./
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 RUN npm pkg delete scripts.prepare && \
     pnpm install --prod --frozen-lockfile
 

--- a/apps/event-service/Dockerfile
+++ b/apps/event-service/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /app
 RUN apk add --no-cache protobuf-dev && \
   npm install -g pnpm
 
-COPY package.json pnpm-lock.yaml ./
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 RUN pnpm install --frozen-lockfile
 
 COPY . .
@@ -37,7 +37,7 @@ ENV HUSKY=0
 RUN apk add --no-cache dumb-init openssl && \
   npm install -g pnpm prisma@6.16.2
 
-COPY package.json pnpm-lock.yaml ./
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 RUN npm pkg delete scripts.prepare && \
     pnpm install --prod --frozen-lockfile
 

--- a/apps/event-service/Dockerfile
+++ b/apps/event-service/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /app
 RUN apk add --no-cache protobuf-dev && \
   npm install -g pnpm
 
-COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+COPY package.json pnpm-lock.yaml ./
 RUN pnpm install --frozen-lockfile
 
 COPY . .
@@ -37,7 +37,7 @@ ENV HUSKY=0
 RUN apk add --no-cache dumb-init openssl && \
   npm install -g pnpm prisma@6.16.2
 
-COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+COPY package.json pnpm-lock.yaml ./
 RUN npm pkg delete scripts.prepare && \
     pnpm install --prod --frozen-lockfile
 

--- a/apps/event-service/Dockerfile
+++ b/apps/event-service/Dockerfile
@@ -5,8 +5,9 @@ WORKDIR /app
 RUN apk add --no-cache protobuf-dev && \
   npm install -g pnpm
 
-COPY package.json pnpm-lock.yaml ./
-RUN pnpm install --frozen-lockfile
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+RUN npm pkg delete scripts.prepare && \
+  pnpm install --frozen-lockfile
 
 COPY . .
 
@@ -37,7 +38,7 @@ ENV HUSKY=0
 RUN apk add --no-cache dumb-init openssl && \
   npm install -g pnpm prisma@6.16.2
 
-COPY package.json pnpm-lock.yaml ./
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 RUN npm pkg delete scripts.prepare && \
     pnpm install --prod --frozen-lockfile
 

--- a/apps/event-service/src/modules/events/domain/events/get-event-status.util.ts
+++ b/apps/event-service/src/modules/events/domain/events/get-event-status.util.ts
@@ -27,8 +27,13 @@ export const getEventStatus = (
         ? inscriptionDeadline
         : new Date(inscriptionDeadline);
 
+    // Comparar solo fechas, sin considerar la hora
+    const nowDateOnly = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+    const deadlineDateOnly = new Date(regDeadline.getFullYear(), regDeadline.getMonth(), regDeadline.getDate());
+    const startDateOnly = new Date(startDate.getFullYear(), startDate.getMonth(), startDate.getDate());
+
     // Registrations closed but event hasn't started
-    if (now >= regDeadline && now < startDate) {
+    if (nowDateOnly > deadlineDateOnly && nowDateOnly < startDateOnly) {
       return EventStatus.REGISTRATION_CLOSED;
     }
   }

--- a/apps/gateway/Dockerfile
+++ b/apps/gateway/Dockerfile
@@ -5,8 +5,9 @@ WORKDIR /app
 RUN apk add --no-cache protobuf-dev && \
   npm install -g pnpm
 
-COPY package.json pnpm-lock.yaml ./
-RUN pnpm install --frozen-lockfile
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+RUN npm pkg delete scripts.prepare && \
+  pnpm install --frozen-lockfile
 
 COPY . .
 
@@ -34,7 +35,7 @@ WORKDIR /app
 RUN apk add --no-cache dumb-init wget && \
   npm install -g pnpm
 
-COPY package.json pnpm-lock.yaml ./
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 RUN npm pkg delete scripts.prepare && \
     pnpm install --prod --frozen-lockfile
 

--- a/apps/invitation-service/Dockerfile
+++ b/apps/invitation-service/Dockerfile
@@ -5,8 +5,9 @@ WORKDIR /app
 RUN apk add --no-cache protobuf-dev && \
   npm install -g pnpm
 
-COPY package.json pnpm-lock.yaml ./
-RUN pnpm install --frozen-lockfile
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+RUN npm pkg delete scripts.prepare && \
+  pnpm install --frozen-lockfile
 
 COPY . .
 
@@ -35,7 +36,7 @@ WORKDIR /app
 RUN apk add --no-cache dumb-init openssl && \
   npm install -g pnpm prisma@6.16.2
 
-COPY package.json pnpm-lock.yaml ./
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 
 RUN npm pkg delete scripts.prepare && \
   pnpm install --prod --frozen-lockfile

--- a/apps/notification-service/Dockerfile
+++ b/apps/notification-service/Dockerfile
@@ -5,8 +5,9 @@ WORKDIR /app
 RUN apk add --no-cache protobuf-dev && \
   npm install -g pnpm
 
-COPY package.json pnpm-lock.yaml ./
-RUN pnpm install --frozen-lockfile
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+RUN npm pkg delete scripts.prepare && \
+  pnpm install --frozen-lockfile
 
 COPY . .
 
@@ -34,7 +35,7 @@ WORKDIR /app
 RUN apk add --no-cache dumb-init && \
   npm install -g pnpm
 
-COPY package.json pnpm-lock.yaml ./
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 RUN npm pkg delete scripts.prepare && \
   pnpm install --prod --frozen-lockfile
 

--- a/apps/project-service/Dockerfile
+++ b/apps/project-service/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /app
 RUN apk add --no-cache protobuf-dev && \
   npm install -g pnpm
 
-COPY package.json pnpm-lock.yaml ./
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 RUN pnpm install --frozen-lockfile
 
 COPY . .
@@ -35,7 +35,7 @@ WORKDIR /app
 RUN apk add --no-cache dumb-init openssl && \
   npm install -g pnpm prisma@6.16.2
 
-COPY package.json pnpm-lock.yaml ./
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 RUN npm pkg delete scripts.prepare && \
   pnpm install --prod --frozen-lockfile
 

--- a/apps/project-service/Dockerfile
+++ b/apps/project-service/Dockerfile
@@ -5,8 +5,9 @@ WORKDIR /app
 RUN apk add --no-cache protobuf-dev && \
   npm install -g pnpm
 
-COPY package.json pnpm-lock.yaml ./
-RUN pnpm install --frozen-lockfile
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+RUN npm pkg delete scripts.prepare && \
+  pnpm install --frozen-lockfile
 
 COPY . .
 
@@ -35,7 +36,7 @@ WORKDIR /app
 RUN apk add --no-cache dumb-init openssl && \
   npm install -g pnpm prisma@6.16.2
 
-COPY package.json pnpm-lock.yaml ./
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 RUN npm pkg delete scripts.prepare && \
   pnpm install --prod --frozen-lockfile
 

--- a/apps/project-service/Dockerfile
+++ b/apps/project-service/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /app
 RUN apk add --no-cache protobuf-dev && \
   npm install -g pnpm
 
-COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+COPY package.json pnpm-lock.yaml ./
 RUN pnpm install --frozen-lockfile
 
 COPY . .
@@ -35,7 +35,7 @@ WORKDIR /app
 RUN apk add --no-cache dumb-init openssl && \
   npm install -g pnpm prisma@6.16.2
 
-COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+COPY package.json pnpm-lock.yaml ./
 RUN npm pkg delete scripts.prepare && \
   pnpm install --prod --frozen-lockfile
 

--- a/apps/project-service/src/modules/projects/application/use-cases/create-project.uc.ts
+++ b/apps/project-service/src/modules/projects/application/use-cases/create-project.uc.ts
@@ -15,7 +15,7 @@ export class CreateProjectUC {
 
   async execute(input: CreateProjectDTO) {
 
-    // 1. validar evento
+    // 1. Validate event
     const event = await this.eventService.getEventById(input.eventId);
     if (!event) {
       throw new NotFoundError('El evento no existe en event-service');
@@ -24,7 +24,7 @@ export class CreateProjectUC {
       throw new ValidationError('El evento está inactivo');
     }
 
-    // 2. si mandan courseId, validamos que exista y que pertenezca al evento
+    // 2. If courseId is provided, validate it exists and belongs to the event
     if (input.courseId) {
       const course = await this.eventService.getCourseById(input.courseId);
       if (!course) {
@@ -42,20 +42,25 @@ export class CreateProjectUC {
     if (!input.courseId || input.courseId <= 0) {
       throw new ValidationError('Invalid courseId');
     }
-    // Asegura que no exista otro proyecto con el mismo nombre en el mismo evento y curso
+    // Ensure no other project with the same name exists for this event and course
     const existing = await this.repo.findProject(input.eventId, input.courseId, input.name.trim());
     if (existing) {
       throw new ValidationError('A project with the same name already exists for this event and course');
     }
   
-    //3. Validar que la fecha límite de inscripción del evento no haya pasado
+    // 3. Validate that the event registration deadline has not passed
     const currentDate = new Date();
     const registrationDeadline = new Date(event.inscriptionDeadline);
-    if (registrationDeadline < currentDate) {
+    
+    // Compare only dates, without considering the time
+    const currentDateOnly = new Date(currentDate.getFullYear(), currentDate.getMonth(), currentDate.getDate());
+    const deadlineDateOnly = new Date(registrationDeadline.getFullYear(), registrationDeadline.getMonth(), registrationDeadline.getDate());
+    
+    if (deadlineDateOnly < currentDateOnly) {
       throw new ValidationError('The event registration deadline has passed');
     }
     
-    //4. Verficar que el evento sea publicJoinable
+    // 4. Verify that the event is publicly joinable
     if (!event.isPubliclyJoinable) {
       throw new ValidationError('The event is not public joinable');
     }

--- a/package.json
+++ b/package.json
@@ -96,5 +96,17 @@
   },
   "prisma": {
     "seed": "ts-node apps/auth-service/prisma/seed.ts"
+  },
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "@nestjs/core",
+      "@prisma/client",
+      "@prisma/engines",
+      "@scarf/scarf",
+      "@swc/core",
+      "bcrypt",
+      "prisma",
+      "protobufjs"
+    ]
   }
 }


### PR DESCRIPTION
**Problem**: Users were unable to register projects on the last day of the registration deadline, receiving a "The event registration deadline has passed" error.

**Root Cause:** The deadline validation was comparing full timestamps (including hours, minutes, seconds) instead of just the date. If the deadline was May 7 at 00:00:00 and a user tried to register at 14:30:00 on May 7, the comparison would fail.

**Solution**
- Modified deadline validation in `create-project.uc.ts` to compare only dates (year/month/day)
- Updated event status calculation in `get-event-status.util.ts` for consistency
- Ensured users can register at any time on the deadline day

**Changes**
- `apps/project-service/src/modules/projects/application/use-cases/create-project.uc.ts`
- `apps/event-service/src/modules/events/domain/events/get-event-status.util.ts`

**I added a small Dockerfile fix:** copy [pnpm-workspace.yaml](vscode-file://vscode-app/c:/Users/USUARIO/AppData/Local/Programs/Microsoft%20VS%20Code/8b640eef5a/resources/app/out/vs/code/electron-browser/workbench/workbench.html) into the image before installs and run npm pkg delete scripts.prepare so pnpm honors allowBuilds and Husky’s prepare hook doesn’t run in the container — applied to both builder and production stages across all services.