### PR TITLE
[CU-86e1arrgj]: add evaluatorIds and projectCode for admin monitoring

### DIFF
--- a/apps/evaluation-service/src/modules/evaluations/application/mappers/evaluation.mapper.ts
+++ b/apps/evaluation-service/src/modules/evaluations/application/mappers/evaluation.mapper.ts
@@ -114,6 +114,7 @@ export class EvaluationMapper {
       averageGrade: stats.averageGrade,
       evaluationCount: stats.evaluationCount,
       categoryStats,
+      evaluatorIds: stats.evaluatorIds || [],
     };
   }
 

--- a/apps/evaluation-service/src/modules/evaluations/domain/repositories/evaluation.repository.port.ts
+++ b/apps/evaluation-service/src/modules/evaluations/domain/repositories/evaluation.repository.port.ts
@@ -16,6 +16,7 @@ export interface ProjectStats {
     averageGrade: number;
     evaluationCount: number;
     categoryStats: CategoryStats[];
+    evaluatorIds?: number[];
 }
 
 export interface EvaluationWithDetails {

--- a/apps/evaluation-service/src/modules/evaluations/infrastructure/prisma/evaluation.prisma.repository.ts
+++ b/apps/evaluation-service/src/modules/evaluations/infrastructure/prisma/evaluation.prisma.repository.ts
@@ -293,10 +293,19 @@ export class EvaluationPrismaRepository implements EvaluationRepositoryPort {
             });
         }
 
+        // Get unique evaluator user IDs for this project
+        const evaluators = await this.prisma.evaluation.findMany({
+            where: { projectId },
+            select: { memberUserId: true },
+        });
+
+        const evaluatorIds = Array.from(new Set(evaluators.map(e => e.memberUserId)));
+
         return {
             averageGrade: gradeStats._avg.grade || 0,
             evaluationCount: gradeStats._count,
             categoryStats,
+            evaluatorIds,
         };
     }
 

--- a/apps/gateway/src/modules/projects/types/project-enrichment.types.ts
+++ b/apps/gateway/src/modules/projects/types/project-enrichment.types.ts
@@ -17,6 +17,7 @@ export type ProjectWithEnrichedJurors = Omit<
   ProjectComplete,
   'createdAt' | 'updatedAt'
 > & {
+  projectCode?: string | null;
   jurorAssignments: JurorKey[];
   jurors: JurorProfile[];
   createdAt: string;

--- a/apps/gateway/src/modules/projects/use-cases/enrich-projects-with-jurors.use-case.ts
+++ b/apps/gateway/src/modules/projects/use-cases/enrich-projects-with-jurors.use-case.ts
@@ -128,6 +128,7 @@ export class EnrichProjectsWithJurorsUseCase {
         id: project.id,
         eventId: project.eventId,
         courseId: project.courseId,
+        projectCode: project.projectCode,
         name: project.name,
         description: project.description,
         state: project.state,

--- a/libs/common/src/protos/evaluation.proto
+++ b/libs/common/src/protos/evaluation.proto
@@ -113,6 +113,7 @@ message GetProjectStatsResponse {
   double averageGrade = 2;
   int32 evaluationCount = 3;
   repeated CategoryStatsResponse categoryStats = 4;
+  repeated int32 evaluatorIds = 5;
 }
 
 message CheckEvaluationStatusRequest {


### PR DESCRIPTION
This pull request enhances the evaluation and project enrichment features by adding support for tracking evaluator user IDs in evaluation statistics and including the `projectCode` in enriched project data. These changes improve the ability to analyze who has evaluated projects and provide more detailed project information in the gateway.

**Evaluation statistics improvements:**
- Added an optional `evaluatorIds` field (array of user IDs) to the `ProjectStats` interface and related gRPC response, allowing consumers to see which users have evaluated a project. [[1]](diffhunk://#diff-8c7844e4c7dd54c9e3f24090c06bb45ebdd2822069272cb85215c7e5bb8f5d90R19) [[2]](diffhunk://#diff-5cc3e46263274d5f50d9f5b4164e735569b91aed608c1820824d1d856f8759b7R116)
- Updated the Prisma repository to fetch and return unique evaluator user IDs as part of project statistics.
- Modified the evaluation mapper to always include `evaluatorIds` (defaulting to an empty array if missing) in mapped results.

**Project enrichment improvements:**
- Added an optional `projectCode` field to the `ProjectWithEnrichedJurors` type to support including project codes in enriched project data.
- Updated the project enrichment use case to populate the `projectCode` field in the returned enriched project objects.