### PR TITLE
made approve and reject send different emails depending on event type

### DIFF
--- a/apps/gateway/src/modules/projects/dto/approve-project.dto.ts
+++ b/apps/gateway/src/modules/projects/dto/approve-project.dto.ts
@@ -1,8 +1,12 @@
-import { IsInt, IsNotEmpty, Min } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+import { IsInt, IsNotEmpty, IsString, Min } from 'class-validator';
 
 export class ApproveProjectDto {
-  @IsInt()
+  @ApiProperty({
+    description: 'Type of event the project is associated with (e.g., "Competition", "Exposition")',
+    example: 'Competition',
+  })
+  @IsString()
   @IsNotEmpty()
-  @Min(1)
-  id: number;
+  eventType: string;
 }

--- a/apps/gateway/src/modules/projects/dto/reject-project.dto.ts
+++ b/apps/gateway/src/modules/projects/dto/reject-project.dto.ts
@@ -10,4 +10,11 @@ export class RejectProjectDto {
   @IsString()
   @IsOptional()
   reason?: string;
+
+  @ApiProperty({
+    description: 'Type of event the project is associated with (e.g., "Competition", "Exposition")',
+    example: 'Competition',
+  })
+  @IsString()
+  eventType: string;
 }

--- a/apps/gateway/src/modules/projects/projects.controller.ts
+++ b/apps/gateway/src/modules/projects/projects.controller.ts
@@ -46,6 +46,7 @@ import { ListProjectsAssignedToJurorDto } from './dto/list-projects-assigned-to-
 import { AddProjectDocumentsMultipartDto } from './dto/add-project-files-multipart.dto';
 import { RequestChangesProjectDto } from './dto/request-changes-project.dto';
 import { UpdateProjectInfoDto } from './dto/update-project-info.dto';
+import { ApproveProjectDto } from './dto/approve-project.dto';
 
 @ApiTags('projects')
 @ApiSecurity('JWT-auth')
@@ -236,8 +237,9 @@ export class ProjectsController {
   approveProject(
     @Param('id', ParseIntPipe) id: number,
     @GetUser() user: AppUser,
+    @Body() approveDto: ApproveProjectDto,
   ) {
-    return this.projectsService.approveProject({ id }, user.id);
+    return this.projectsService.approveProject({ id, ...approveDto }, user.id);
   }
 
   // TODO: Add platform permission guard - only admins/event managers can reject projects

--- a/apps/gateway/src/modules/projects/projects.service.ts
+++ b/apps/gateway/src/modules/projects/projects.service.ts
@@ -388,11 +388,12 @@ export class ProjectsService implements OnModuleInit {
     return this.removeJurorFromProjectUseCase.execute(dto);
   }
 
-  async approveProject(dto: ApproveProjectDto, actingUserId: number) {
+  async approveProject(dto: {id: number; eventType: string}, actingUserId: number) {
     const response = await firstValueFrom(
       this.projectsService.approveProject({
         id: dto.id,
-        actingUserId,
+        actingUserId: actingUserId,
+        eventType: dto.eventType,
       }),
     );
 
@@ -400,7 +401,7 @@ export class ProjectsService implements OnModuleInit {
   }
 
   async rejectProject(
-    dto: { id: number; reason?: string },
+    dto: { id: number; reason?: string; eventType: string },
     actingUserId: number,
   ) {
     const response = await firstValueFrom(
@@ -408,6 +409,7 @@ export class ProjectsService implements OnModuleInit {
         id: dto.id,
         actingUserId,
         reason: dto.reason,
+        eventType: dto.eventType,
       }),
     );
 

--- a/apps/project-service/src/modules/projects/application/use-cases/approve-project.uc.ts
+++ b/apps/project-service/src/modules/projects/application/use-cases/approve-project.uc.ts
@@ -1,16 +1,19 @@
 import { Injectable, Inject, OnModuleInit } from '@nestjs/common';
 import { ProjectRepository } from '../../domain/repositories/project.repository';
 import { NotFoundError, ValidationError } from '../../domain/errors';
+import { NOTIFICATION_SERVICE_PORT, NotificationServicePort } from '../ports/notification-service.port';
+import { EmailTemplate } from '@app/common/generated/notification';
 
 @Injectable()
 export class ApproveProjectUC implements OnModuleInit {
   constructor(
     @Inject('ProjectRepository') private readonly repo: ProjectRepository,
+    @Inject(NOTIFICATION_SERVICE_PORT) private readonly notificationService: NotificationServicePort,
   ) { }
 
   onModuleInit() {}
 
-  async execute(input: { id: number; actingUserId: number }) {
+  async execute(input: { id: number; actingUserId: number, eventType: string }) {
     const project = await this.repo.findById(input.id);
     if (!project) throw new NotFoundError('Project not found');
     //console.log('Approving project:', project);
@@ -26,9 +29,32 @@ export class ApproveProjectUC implements OnModuleInit {
       );
     }
 
+    const projectUpdated = await this.repo.setProjectState(project.id!, 'APPROVED');
 
-    const projecto = await this.repo.setProjectState(project.id!, 'APPROVED');
+    // Notify all pending participants about the approval
+    const pendings = await this.repo.listPendingParticipants(project.id!);
+    const template = input.eventType === 'Competition' ? EmailTemplate.PARTICIPANTS_APPROVED : EmailTemplate.PROJECT_APPROVED;
 
-    return projecto;
+    for (const pending of pendings) {
+      const firstName = pending.firstName || 'Estudiante';
+      const lastName = pending.lastName || '';
+
+      try {
+        await this.notificationService.sendEmail({
+          to: pending.email,
+          template,
+          params: {
+            firstName,
+            lastName,
+            projectName: project.name,
+          },
+        });
+      } catch (error) {
+        console.error(`Failed to send approval email to ${pending.email}:`, error);
+        // Continue sending to other participants even if one fails
+      }
+    }
+
+    return projectUpdated;
   }
 }

--- a/apps/project-service/src/modules/projects/application/use-cases/reject-project.uc.ts
+++ b/apps/project-service/src/modules/projects/application/use-cases/reject-project.uc.ts
@@ -13,7 +13,7 @@ export class RejectProjectUC {
     private readonly notificationService: NotificationServicePort,
   ) {}
 
-  async execute(input: { id: number; actingUserId: number; reason?: string }) {
+  async execute(input: { id: number; actingUserId: number; reason?: string, eventType: string }) {
     const project = await this.repo.findById(input.id);
     if (!project) throw new NotFoundError('Project not found');
 
@@ -37,6 +37,7 @@ export class RejectProjectUC {
 
     // Notify all pending participants about the rejection
     const pendings = await this.repo.listPendingParticipants(project.id!);
+    const template = input.eventType === 'Competition' ? EmailTemplate.PARTICIPANTS_REJECTED : EmailTemplate.PROJECT_REJECTED;
 
     for (const pending of pendings) {
       const firstName = pending.firstName || 'Estudiante';
@@ -45,7 +46,7 @@ export class RejectProjectUC {
       try {
         await this.notificationService.sendEmail({
           to: pending.email,
-          template: EmailTemplate.PROJECT_REJECTED,
+          template,
           params: {
             firstName,
             lastName,

--- a/apps/project-service/src/modules/projects/interface/grpc/projects.controller.ts
+++ b/apps/project-service/src/modules/projects/interface/grpc/projects.controller.ts
@@ -174,10 +174,11 @@ export class ProjectsController {
   }
 
   @GrpcMethod('ProjectsService', 'ApproveProject')
-  async approveProjectRpc(req: { id: number; actingUserId: number }) {
+  async approveProjectRpc(req: { id: number; actingUserId: number, eventType: string }) {
     const updated = await this.approveProjectUC.execute({
       id: req.id,
       actingUserId: req.actingUserId,
+      eventType: req.eventType,
     });
     return { project: toProtoProject(updated) };
   }
@@ -187,11 +188,13 @@ export class ProjectsController {
     id: number;
     actingUserId: number;
     reason?: string;
+    eventType: string;
   }) {
     const updated = await this.rejectProjectUC.execute({
       id: req.id,
       actingUserId: req.actingUserId,
       reason: req.reason,
+      eventType: req.eventType,
     });
     return { project: toProtoProject(updated) };
   }

--- a/libs/common/src/protos/project.proto
+++ b/libs/common/src/protos/project.proto
@@ -205,12 +205,14 @@ message UpdateProjectRequest {
 message ApproveProjectRequest { 
   int32 id = 1; 
   int32 actingUserId = 2; 
+  string eventType = 3;
 }
 
 message RejectProjectRequest { 
   int32 id = 1; 
   int32 actingUserId = 2;
   optional string reason = 3; // Reason for rejection (stored in database)
+  string eventType = 4;
 }
 
 message RequestChangesProjectRequest {


### PR DESCRIPTION
changed PATCH /projects/:id/approve and PATCH /projects/:id/reject to include the eventType, which is used to differentiate whether the event is an Exposition or a Competition. If the former, the PROJECT_[APPROVED|REJECTED] email is sent. Otherwise, the PARTICIPANTS_[APPROVED|REJECTED] is sent. adjusted proto files for that too.