### PR TITLE
[CU-86e1c0jtr]: - Project Service - PATCH endpoint for participant to…

### DIFF
--- a/apps/gateway/src/modules/projects/dto/update-project-code.dto.ts
+++ b/apps/gateway/src/modules/projects/dto/update-project-code.dto.ts
@@ -1,0 +1,13 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsString, IsNotEmpty } from 'class-validator';
+
+export class UpdateProjectCodeDto {
+  @ApiProperty({
+    description: 'The new project code',
+    type: String,
+    example: 'PROJ-2024-001',
+  })
+  @IsString()
+  @IsNotEmpty()
+  projectCode!: string;
+}

--- a/apps/gateway/src/modules/projects/projects.controller.ts
+++ b/apps/gateway/src/modules/projects/projects.controller.ts
@@ -46,6 +46,7 @@ import { ListProjectsAssignedToJurorDto } from './dto/list-projects-assigned-to-
 import { AddProjectDocumentsMultipartDto } from './dto/add-project-files-multipart.dto';
 import { RequestChangesProjectDto } from './dto/request-changes-project.dto';
 import { UpdateProjectInfoDto } from './dto/update-project-info.dto';
+import { UpdateProjectCodeDto } from './dto/update-project-code.dto';
 import { ApproveProjectDto } from './dto/approve-project.dto';
 
 @ApiTags('projects')
@@ -526,6 +527,50 @@ export class ProjectsController {
       updateProjectInfoDto.name,
       updateProjectInfoDto.description,
     );
+  }
+
+  @Patch(':id/code')
+  @ApiOperation({
+    summary: 'Update project code',
+    description:
+      'Updates the project code. Only allowed when the project is in REQUEST_CHANGES state and the user is a participant of the project.',
+  })
+  @ApiParam({
+    name: 'id',
+    description: 'Project ID',
+    example: 1,
+  })
+  @ApiBody({
+    description: 'Project code to update',
+    type: UpdateProjectCodeDto,
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Project code updated successfully',
+  })
+  @ApiResponse({
+    status: 400,
+    description: 'Invalid input data or project is not in REQUEST_CHANGES state',
+  })
+  @ApiResponse({
+    status: 403,
+    description: 'Forbidden - User is not a participant of the project',
+  })
+  @ApiResponse({
+    status: 404,
+    description: 'Project not found',
+  })
+  async updateProjectCode(
+    @Param('id', ParseIntPipe) id: number,
+    @Body() updateProjectCodeDto: UpdateProjectCodeDto,
+    @GetUser() user: AppUser,
+  ) {
+    await this.projectsService.updateProjectCode(
+      id,
+      updateProjectCodeDto.projectCode,
+      user.id,
+    );
+    return { message: 'Project code updated successfully' };
   }
 
   @Get(':id/jurors')

--- a/apps/gateway/src/modules/projects/projects.module.ts
+++ b/apps/gateway/src/modules/projects/projects.module.ts
@@ -14,6 +14,7 @@ import { FetchUserProfilesUseCase } from './use-cases/fetch-user-profiles.use-ca
 import { EnrichProjectsWithJurorsUseCase } from './use-cases/enrich-projects-with-jurors.use-case';
 import { ValidateJurorHasNotEvaluatedUseCase } from './use-cases/validate-juror-has-not-evaluated.use-case';
 import { RemoveJurorFromProjectUseCase } from './use-cases/remove-juror-from-project.use-case';
+import { UpdateProjectCodeUseCase } from './use-cases/update-project-code.use-case';
 
 import {
   EVENT_SERVICE_NAME,
@@ -114,6 +115,7 @@ import { AuthModule } from '../auth/auth.module';
     EnrichProjectsWithJurorsUseCase,
     ValidateJurorHasNotEvaluatedUseCase,
     RemoveJurorFromProjectUseCase,
+    UpdateProjectCodeUseCase,
   ],
   exports: [ProjectsService],
 })

--- a/apps/gateway/src/modules/projects/projects.service.ts
+++ b/apps/gateway/src/modules/projects/projects.service.ts
@@ -88,9 +88,9 @@ export type {
 @Injectable()
 export class ProjectsService implements OnModuleInit {
   private readonly logger = new Logger(ProjectsService.name);
-  private projectsService!: ProjectsServiceClient;
-  private eventsService!: EventServiceClient;
-  private evaluationService!: EvaluationServiceClient;
+  private projectsService: ProjectsServiceClient;
+  private eventsService: EventServiceClient;
+  private evaluationService: EvaluationServiceClient;
   constructor(
     @Inject(PROJECTS_SERVICE_NAME) private readonly projectsClient: ClientGrpc,
     @Inject(EVENT_SERVICE_NAME) private readonly eventsClient: ClientGrpc,

--- a/apps/gateway/src/modules/projects/projects.service.ts
+++ b/apps/gateway/src/modules/projects/projects.service.ts
@@ -5,6 +5,7 @@ import {
   BadRequestException,
   Logger,
   NotFoundException,
+  ForbiddenException,
 } from '@nestjs/common';
 import { ClientGrpc } from '@nestjs/microservices';
 import { firstValueFrom, lastValueFrom } from 'rxjs';
@@ -71,6 +72,7 @@ import { FetchUserProfilesUseCase } from './use-cases/fetch-user-profiles.use-ca
 import { EnrichProjectsWithJurorsUseCase } from './use-cases/enrich-projects-with-jurors.use-case';
 import { ValidateJurorHasNotEvaluatedUseCase } from './use-cases/validate-juror-has-not-evaluated.use-case';
 import { RemoveJurorFromProjectUseCase } from './use-cases/remove-juror-from-project.use-case';
+import { UpdateProjectCodeUseCase } from './use-cases/update-project-code.use-case';
 import {
   ProjectWithEnrichedJurors,
   ListProjectsWithJurorsResponse,
@@ -86,9 +88,9 @@ export type {
 @Injectable()
 export class ProjectsService implements OnModuleInit {
   private readonly logger = new Logger(ProjectsService.name);
-  private projectsService: ProjectsServiceClient;
-  private eventsService: EventServiceClient;
-  private evaluationService: EvaluationServiceClient;
+  private projectsService!: ProjectsServiceClient;
+  private eventsService!: EventServiceClient;
+  private evaluationService!: EvaluationServiceClient;
   constructor(
     @Inject(PROJECTS_SERVICE_NAME) private readonly projectsClient: ClientGrpc,
     @Inject(EVENT_SERVICE_NAME) private readonly eventsClient: ClientGrpc,
@@ -101,6 +103,7 @@ export class ProjectsService implements OnModuleInit {
     private readonly enrichProjectsWithJurorsUseCase: EnrichProjectsWithJurorsUseCase,
     private readonly validateJurorHasNotEvaluatedUseCase: ValidateJurorHasNotEvaluatedUseCase,
     private readonly removeJurorFromProjectUseCase: RemoveJurorFromProjectUseCase,
+    private readonly updateProjectCodeUseCase: UpdateProjectCodeUseCase,
   ) {}
 
   onModuleInit() {
@@ -123,7 +126,7 @@ export class ProjectsService implements OnModuleInit {
    */
   async createProjectWithParticipantsAndFiles(
     body: CreateProjectWithParticipantsMultipartDto,
-    files: Express.Multer.File[],
+    files: any[],
   ) {
     this.logger.log(
       `Creating project with ${files.length} files: ${body.name}`,
@@ -140,7 +143,7 @@ export class ProjectsService implements OnModuleInit {
     if (body.participants) {
       try {
         participants = JSON.parse(body.participants);
-      } catch (error) {
+      } catch (error: any) {
         throw new BadRequestException(
           'Invalid participants format. Must be a valid JSON array.',
         );
@@ -151,7 +154,7 @@ export class ProjectsService implements OnModuleInit {
     if (body.documents) {
       try {
         documentMetadata = JSON.parse(body.documents);
-      } catch (error) {
+      } catch (error: any) {
         throw new BadRequestException(
           'Invalid documents format. Must be a valid JSON array.',
         );
@@ -256,7 +259,7 @@ export class ProjectsService implements OnModuleInit {
       this.logger.log(
         `Project created successfully with ID: ${createdProject.id}`,
       );
-    } catch (error) {
+    } catch (error: any) {
       this.logger.error(
         `Failed to create project: ${error.message}`,
         error.stack,
@@ -274,7 +277,7 @@ export class ProjectsService implements OnModuleInit {
       );
       uploadResults = await Promise.all(uploadPromises);
       this.logger.log(`Successfully uploaded ${uploadResults.length} files`);
-    } catch (error) {
+    } catch (error: any) {
       this.logger.error(
         `Failed to upload files to Azure: ${error.message}`,
         error.stack,
@@ -299,7 +302,7 @@ export class ProjectsService implements OnModuleInit {
       this.logger.log(
         `Successfully attached ${uploadResults.length} documents to project ${createdProject.id}`,
       );
-    } catch (error) {
+    } catch (error: any) {
       this.logger.error(
         `Failed to attach documents to project: ${error.message}`,
         error.stack,
@@ -351,7 +354,7 @@ export class ProjectsService implements OnModuleInit {
       studentCode: dto.studentCode,
       semester: dto.semester ?? '',
       career: dto.career ?? '',
-      status: dto.status ?? 1, // Default to PENDING if not provided
+      status: dto.status ? String(dto.status) : 'PENDING',
     };
 
     return firstValueFrom(
@@ -554,7 +557,7 @@ export class ProjectsService implements OnModuleInit {
   async updateProjectDocument(
     id: number,
     dto: UpdateProjectDocumentDto,
-    file?: Express.Multer.File,
+    file?: any,
   ): Promise<ProjectDocument> {
     const request: UpdateProjectDocumentRequest = { id };
 
@@ -594,6 +597,15 @@ export class ProjectsService implements OnModuleInit {
         description,
       }),
     );
+  }
+
+  async updateProjectCode(
+    id: number,
+    projectCode: string,
+    userId: number,
+  ): Promise<void> {
+    // Delegate to the use-case which contains the business rules
+    return this.updateProjectCodeUseCase.execute(id, projectCode, userId);
   }
 
   async listJurorsByProjectId(projectId: number) {
@@ -697,7 +709,7 @@ export class ProjectsService implements OnModuleInit {
   async addFilesToExistingProject(
     projectId: number,
     body: AddProjectDocumentsMultipartDto,
-    files: Express.Multer.File[],
+    files: any[],
   ) {
     this.logger.log(`Adding ${files.length} file(s) to project ${projectId}`);
 
@@ -706,7 +718,7 @@ export class ProjectsService implements OnModuleInit {
     if (body.documents) {
       try {
         documentMetadata = JSON.parse(body.documents);
-      } catch (error) {
+      } catch (error: any) {
         throw new BadRequestException(
           'Invalid documents format. Must be a valid JSON array.',
         );
@@ -863,7 +875,7 @@ export class ProjectsService implements OnModuleInit {
       );
       uploadResults = await Promise.all(uploadPromises);
       this.logger.log(`Successfully uploaded ${uploadResults.length} files`);
-    } catch (error) {
+    } catch (error: any) {
       this.logger.error(
         `Failed to upload files to Azure: ${error.message}`,
         error.stack,
@@ -889,7 +901,7 @@ export class ProjectsService implements OnModuleInit {
       this.logger.log(
         `Successfully attached ${uploadResults.length} documents to project ${projectId}`,
       );
-    } catch (error) {
+    } catch (error: any) {
       this.logger.error(
         `Failed to attach documents to project: ${error.message}`,
         error.stack,

--- a/apps/gateway/src/modules/projects/use-cases/update-project-code.use-case.spec.ts
+++ b/apps/gateway/src/modules/projects/use-cases/update-project-code.use-case.spec.ts
@@ -1,0 +1,48 @@
+import { of } from 'rxjs';
+import { UpdateProjectCodeUseCase } from './update-project-code.use-case';
+import { BadRequestException, NotFoundException, ForbiddenException } from '@nestjs/common';
+import { ProjectState } from '@app/common/generated/project';
+
+describe('UpdateProjectCodeUseCase', () => {
+  const mockGetService = (service: any) => ({ getService: () => service });
+
+  it('updates code when project in REQUEST_CHANGES and user is participant', async () => {
+    const project = { id: 1, state: ProjectState.REQUEST_CHANGES, participants: [{ userId: 10 }] } as any;
+    const projectsService = {
+      getProjectComplete: () => of({ items: [project] }),
+      updateProject: jest.fn(() => of({})),
+    };
+
+    // @ts-ignore
+    const useCase = new UpdateProjectCodeUseCase(mockGetService(projectsService));
+
+    await expect(useCase.execute(1, 'CODE-1', 10)).resolves.toBeUndefined();
+    expect(projectsService.updateProject).toHaveBeenCalledWith({ id: 1, projectCode: 'CODE-1' });
+  });
+
+  it('throws NotFoundException when project not found', async () => {
+    const projectsService = { getProjectComplete: () => of({ items: [] }) };
+    // @ts-ignore
+    const useCase = new UpdateProjectCodeUseCase(mockGetService(projectsService));
+
+    await expect(useCase.execute(1, 'CODE', 1)).rejects.toBeInstanceOf(NotFoundException);
+  });
+
+  it('throws BadRequestException when state is not REQUEST_CHANGES', async () => {
+    const project = { id: 1, state: ProjectState.APPROVED, participants: [{ userId: 1 }] } as any;
+    const projectsService = { getProjectComplete: () => of({ items: [project] }) };
+    // @ts-ignore
+    const useCase = new UpdateProjectCodeUseCase(mockGetService(projectsService));
+
+    await expect(useCase.execute(1, 'CODE', 1)).rejects.toBeInstanceOf(BadRequestException);
+  });
+
+  it('throws ForbiddenException when user not a participant', async () => {
+    const project = { id: 1, state: ProjectState.REQUEST_CHANGES, participants: [{ userId: 2 }] } as any;
+    const projectsService = { getProjectComplete: () => of({ items: [project] }) };
+    // @ts-ignore
+    const useCase = new UpdateProjectCodeUseCase(mockGetService(projectsService));
+
+    await expect(useCase.execute(1, 'CODE', 1)).rejects.toBeInstanceOf(ForbiddenException);
+  });
+});

--- a/apps/gateway/src/modules/projects/use-cases/update-project-code.use-case.ts
+++ b/apps/gateway/src/modules/projects/use-cases/update-project-code.use-case.ts
@@ -1,0 +1,73 @@
+import { Injectable, Inject, Logger, NotFoundException, BadRequestException, ForbiddenException } from '@nestjs/common';
+import { ClientGrpc } from '@nestjs/microservices';
+import { lastValueFrom } from 'rxjs';
+import {
+  PROJECTS_SERVICE_NAME,
+  ProjectsServiceClient,
+  GetProjectRequest,
+  UpdateProjectRequest,
+  ProjectCompleteResponse,
+  ProjectComplete,
+  ProjectState,
+  ProjectParticipant,
+} from '@app/common/generated/project';
+
+@Injectable()
+export class UpdateProjectCodeUseCase {
+  private readonly logger = new Logger(UpdateProjectCodeUseCase.name);
+  private projectsService: ProjectsServiceClient;
+
+  constructor(
+    @Inject(PROJECTS_SERVICE_NAME) private readonly projectsClient: ClientGrpc,
+  ) {
+    this.projectsService = this.projectsClient.getService<ProjectsServiceClient>(
+      PROJECTS_SERVICE_NAME,
+    );
+  }
+
+  /**
+   * Update a project's code after validating business rules
+   */
+  async execute(id: number, projectCode: string, actingUserId: number): Promise<void> {
+    const request: GetProjectRequest = { id };
+
+    const res: ProjectCompleteResponse = await lastValueFrom(
+      this.projectsService.getProjectComplete(request),
+    );
+
+    const project: ProjectComplete | undefined = res.items?.[0];
+
+    if (!project) {
+      throw new NotFoundException('Project not found');
+    }
+
+    if (project.state !== ProjectState.REQUEST_CHANGES) {
+      throw new BadRequestException(
+        `Project can only have its code updated when in REQUEST_CHANGES state. Current state: ${ProjectState[project.state]}`,
+      );
+    }
+
+    const participants: ProjectParticipant[] = project.participants ?? [];
+
+    // Note: pendingParticipants objects do not include a userId in the proto
+    // so we only consider confirmed `participants` (those linked to a userId).
+    const isParticipant = participants.some(
+      (p: ProjectParticipant) => p.userId === actingUserId,
+    );
+
+    if (!isParticipant) {
+      throw new ForbiddenException(
+        'Only participants of the project can update the project code',
+      );
+    }
+
+    this.logger.log(`Updating project ${id} code to ${projectCode} by user ${actingUserId}`);
+
+    const updateRequest: UpdateProjectRequest = {
+      id,
+      projectCode,
+    };
+
+    await lastValueFrom(this.projectsService.updateProject(updateRequest));
+  }
+}


### PR DESCRIPTION
This pull request introduces a new feature that allows updating a project's code, but only when the project is in the REQUEST_CHANGES state and the user is a participant. It adds the necessary DTO, controller endpoint, service logic, and a dedicated use case with business rule validation. Additionally, it includes comprehensive tests for the new use case and makes minor improvements to typing and error handling in related service methods.

**Feature: Update Project Code**

* Added `UpdateProjectCodeDto` for validating and documenting the payload for updating a project's code.
* Introduced a new PATCH endpoint `PATCH /projects/:id/code` in `ProjectsController` that uses the new DTO and delegates to the service layer for business logic. [[1]](diffhunk://#diff-a57eefe7d129051a7844fd2fd9287201e436a6df903753e94469422395267582R49) [[2]](diffhunk://#diff-a57eefe7d129051a7844fd2fd9287201e436a6df903753e94469422395267582R532-R575)
* Implemented the `UpdateProjectCodeUseCase` class to encapsulate business rules: only participants can update the code, and only if the project is in the REQUEST_CHANGES state.
* Registered the new use case in the module and injected it into the service. [[1]](diffhunk://#diff-bcc2685583f77d26b73e25842bf2d0a7b2cebcacda06fc7819d2c0cc3f23e566R17) [[2]](diffhunk://#diff-bcc2685583f77d26b73e25842bf2d0a7b2cebcacda06fc7819d2c0cc3f23e566R118) [[3]](diffhunk://#diff-0d492fb876ece85f483ee787d4d5711b9f3d8dd07ae9eace2b617f66a4e818c0R75) [[4]](diffhunk://#diff-0d492fb876ece85f483ee787d4d5711b9f3d8dd07ae9eace2b617f66a4e818c0R106)

**Testing**

* Added unit tests for `UpdateProjectCodeUseCase`, covering success and all relevant failure scenarios (not found, wrong state, not a participant).

**Service Improvements**

* Added the `updateProjectCode` method to `ProjectsService`, delegating to the new use case.
* Improved error handling and typing in several service methods, including more specific error typing and status handling. [[1]](diffhunk://#diff-0d492fb876ece85f483ee787d4d5711b9f3d8dd07ae9eace2b617f66a4e818c0L126-R129) [[2]](diffhunk://#diff-0d492fb876ece85f483ee787d4d5711b9f3d8dd07ae9eace2b617f66a4e818c0L143-R146) [[3]](diffhunk://#diff-0d492fb876ece85f483ee787d4d5711b9f3d8dd07ae9eace2b617f66a4e818c0L154-R157) [[4]](diffhunk://#diff-0d492fb876ece85f483ee787d4d5711b9f3d8dd07ae9eace2b617f66a4e818c0L259-R262) [[5]](diffhunk://#diff-0d492fb876ece85f483ee787d4d5711b9f3d8dd07ae9eace2b617f66a4e818c0L277-R280) [[6]](diffhunk://#diff-0d492fb876ece85f483ee787d4d5711b9f3d8dd07ae9eace2b617f66a4e818c0L302-R305) [[7]](diffhunk://#diff-0d492fb876ece85f483ee787d4d5711b9f3d8dd07ae9eace2b617f66a4e818c0L354-R357) [[8]](diffhunk://#diff-0d492fb876ece85f483ee787d4d5711b9f3d8dd07ae9eace2b617f66a4e818c0L557-R560) [[9]](diffhunk://#diff-0d492fb876ece85f483ee787d4d5711b9f3d8dd07ae9eace2b617f66a4e818c0L700-R712) [[10]](diffhunk://#diff-0d492fb876ece85f483ee787d4d5711b9f3d8dd07ae9eace2b617f66a4e818c0L709-R721) [[11]](diffhunk://#diff-0d492fb876ece85f483ee787d4d5711b9f3d8dd07ae9eace2b617f66a4e818c0L866-R878) [[12]](diffhunk://#diff-0d492fb876ece85f483ee787d4d5711b9f3d8dd07ae9eace2b617f66a4e818c0L892-R904)

These changes collectively ensure that project codes can only be updated under strict conditions, improving both security and data integrity.… update ProjectCode