### PR TITLE
[CU-86e1fntzr]: Back-Status-Joined

### DIFF
--- a/apps/invitation-service/src/modules/invitations/application/use-cases/accept-invitation.use-case.ts
+++ b/apps/invitation-service/src/modules/invitations/application/use-cases/accept-invitation.use-case.ts
@@ -101,13 +101,28 @@ export class AcceptInvitationUseCase {
           });
         }
 
-        const studentCode = dto.studentCode?.trim();
+          const pendingParticipants = await this.projectService.listPendingParticipants(
+            invitation.targetId,
+          );
+
+          const studentCode = pendingParticipants.find(
+            (participant) =>
+              participant.email.trim().toLowerCase() ===
+              invitation.email.trim().toLowerCase(),
+          )?.studentCode?.trim();
+
+          if (!studentCode) {
+            throw new RpcException({
+              code: status.INVALID_ARGUMENT,
+              message: 'studentCode could not be resolved from pending participants for this invitation',
+            });
+          }
 
         // Add as project participant
         await this.projectService.addParticipant({
           userId: invitation.invitedUserId,
           projectId: invitation.targetId,
-          studentCode: dto.studentCode || '',
+            studentCode,
         });
 
         // Once the user is a project participant, assign event roles

--- a/apps/invitation-service/src/modules/invitations/application/use-cases/tests/accept-invitation.use-case.spec.ts
+++ b/apps/invitation-service/src/modules/invitations/application/use-cases/tests/accept-invitation.use-case.spec.ts
@@ -12,11 +12,15 @@ import {
 } from '../../../domain/entities/invitation.entity';
 import { InvitationRole } from '../../../domain/entities/invitation-role.entity';
 import {
-  AUTH_SERVICE_NAME,
   AuthServiceClient,
 } from '../../../../../../../../libs/common/src/generated/auth';
-import { EventServiceClient } from '../../../../../../../../libs/common/src/generated/event';
-import { EVENT_SERVICE_NAME } from '../../../invitations.module';
+import {
+  EventServiceClient,
+} from '../../../../../../../../libs/common/src/generated/event';
+import { ProjectsServiceClient } from '../../../../../../../../libs/common/src/generated/project';
+import { AuthServicePort } from '../../../infrastructure/ports/auth-service.port';
+import { EventServicePort } from '../../../infrastructure/ports/event-service.port';
+import { ProjectServicePort } from '../../../infrastructure/ports/project-service.port';
 
 describe('AcceptInvitationUseCase', () => {
   let useCase: AcceptInvitationUseCase;
@@ -24,6 +28,7 @@ describe('AcceptInvitationUseCase', () => {
   let invitationRoleRepository: jest.Mocked<InvitationRoleRepositoryPort>;
   let authService: jest.Mocked<AuthServiceClient>;
   let eventService: jest.Mocked<EventServiceClient>;
+  let projectService: jest.Mocked<ProjectServicePort>;
 
   beforeEach(async () => {
     const mockInvitationRepository = {
@@ -56,13 +61,13 @@ describe('AcceptInvitationUseCase', () => {
       createEventMember: jest.fn(),
     };
 
-    const mockAuthClientGrpc = {
-      getService: jest.fn().mockReturnValue(mockAuthService),
+    const mockProjectService = {
+      getProject: jest.fn(),
+      addParticipant: jest.fn(),
+      listPendingParticipants: jest.fn(),
     };
 
-    const mockEventClientGrpc = {
-      getService: jest.fn().mockReturnValue(mockEventService),
-    };
+    mockAuthService.getUser.mockResolvedValue({ status: 'ACTIVE' } as any);
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -76,12 +81,16 @@ describe('AcceptInvitationUseCase', () => {
           useValue: mockInvitationRoleRepository,
         },
         {
-          provide: AUTH_SERVICE_NAME,
-          useValue: mockAuthClientGrpc,
+          provide: AuthServicePort,
+          useValue: mockAuthService,
         },
         {
-          provide: EVENT_SERVICE_NAME,
-          useValue: mockEventClientGrpc,
+          provide: EventServicePort,
+          useValue: mockEventService,
+        },
+        {
+          provide: ProjectServicePort,
+          useValue: mockProjectService,
         },
       ],
     }).compile();
@@ -90,11 +99,9 @@ describe('AcceptInvitationUseCase', () => {
     invitationRepository = module.get(InvitationRepositoryPort);
     invitationRoleRepository = module.get(InvitationRoleRepositoryPort);
 
-    // Trigger onModuleInit
-    await useCase.onModuleInit();
-
     authService = mockAuthService as Partial<AuthServiceClient> as jest.Mocked<AuthServiceClient>;
     eventService = mockEventService as Partial<EventServiceClient> as jest.Mocked<EventServiceClient>;
+    projectService = mockProjectService as Partial<ProjectServicePort> as jest.Mocked<ProjectServicePort>;
   });
 
   afterEach(() => {
@@ -128,6 +135,7 @@ describe('AcceptInvitationUseCase', () => {
 
       invitationRepository.findByToken.mockResolvedValue(invitation);
       invitationRoleRepository.findByInvitationId.mockResolvedValue(roles);
+      (authService.getUser as jest.Mock).mockResolvedValue({ status: 'PENDING' });
       authService.activateUser.mockReturnValue(of({}) as any);
       authService.assignPlatformRoles.mockReturnValue(of({}) as any);
       invitationRepository.save.mockResolvedValue(invitation);
@@ -212,12 +220,14 @@ describe('AcceptInvitationUseCase', () => {
 
       invitationRepository.findByToken.mockResolvedValue(invitation);
       invitationRoleRepository.findByInvitationId.mockResolvedValue([]);
+      (authService.getUser as jest.Mock).mockResolvedValue({ status: 'PENDING' });
       authService.updateUser.mockReturnValue(of({}) as any);
       invitationRepository.save.mockResolvedValue(invitation);
 
       // Act
       const result = await useCase.execute({
         token: 'token-abc',
+        password: 'securePassword123',
         firstName: 'John',
         lastName: 'Doe',
       });
@@ -421,7 +431,7 @@ describe('AcceptInvitationUseCase', () => {
       );
     });
 
-    it('should throw UNIMPLEMENTED for project invitations', async () => {
+    it('should accept project invitation using pending participant studentCode', async () => {
       // Arrange
       const futureDate = new Date();
       futureDate.setDate(futureDate.getDate() + 7);
@@ -442,15 +452,93 @@ describe('AcceptInvitationUseCase', () => {
 
       invitationRepository.findByToken.mockResolvedValue(invitation);
       invitationRoleRepository.findByInvitationId.mockResolvedValue([]);
+      projectService.getProject.mockResolvedValue({
+        id: 10,
+        eventId: 99,
+        name: 'Project A',
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+        courseId: 1,
+        state: 1,
+      } as any);
+      projectService.listPendingParticipants.mockResolvedValue([
+        {
+          pendingId: 1,
+          projectId: 10,
+          firstName: 'Jane',
+          lastName: 'Doe',
+          email: 'user@example.com',
+          studentCode: '2023001',
+          semester: '7',
+          career: 'Engineering',
+          status: 'PENDING',
+          invitedAt: new Date().toISOString(),
+          joinedAt: '',
+          createdAt: new Date().toISOString(),
+          updatedAt: new Date().toISOString(),
+        },
+      ] as any);
+      projectService.addParticipant.mockReturnValue(of({ participant: {} } as any) as any);
+      eventService.createEventMember.mockReturnValue(of({}) as any);
+      invitationRepository.save.mockResolvedValue(invitation);
+
+      // Act
+      const result = await useCase.execute({ token: 'token-abc' });
+
+      // Assert
+      expect(result).toEqual({ success: true });
+      expect(projectService.listPendingParticipants).toHaveBeenCalledWith(10);
+      expect(projectService.addParticipant).toHaveBeenCalledWith({
+        userId: 200,
+        projectId: 10,
+        studentCode: '2023001',
+      });
+      expect(eventService.createEventMember).not.toHaveBeenCalled();
+      expect(invitation.status).toBe(InvitationStatus.ACCEPTED);
+      expect(invitationRepository.save).toHaveBeenCalledWith(invitation);
+    });
+
+    it('should throw INVALID_ARGUMENT when project pending participant is missing', async () => {
+      // Arrange
+      const futureDate = new Date();
+      futureDate.setDate(futureDate.getDate() + 7);
+
+      const invitation = new Invitation(
+        'inv-123',
+        'token-abc',
+        'user@example.com',
+        InvitationTargetType.PROJECT,
+        10,
+        InvitationStatus.PENDING,
+        futureDate,
+        100,
+        200,
+        new Date(),
+        new Date(),
+      );
+
+      invitationRepository.findByToken.mockResolvedValue(invitation);
+      invitationRoleRepository.findByInvitationId.mockResolvedValue([]);
+      projectService.getProject.mockResolvedValue({
+        id: 10,
+        eventId: 99,
+        name: 'Project A',
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+        courseId: 1,
+        state: 1,
+      } as any);
+      projectService.listPendingParticipants.mockResolvedValue([] as any);
 
       // Act & Assert
       await expect(useCase.execute({ token: 'token-abc' })).rejects.toThrow(
         new RpcException({
-          code: status.UNIMPLEMENTED,
-          message: 'Project invitation acceptance is not yet implemented',
+          code: status.INVALID_ARGUMENT,
+          message: 'studentCode could not be resolved from pending participants for this invitation',
         }),
       );
 
+      expect(projectService.addParticipant).not.toHaveBeenCalled();
       expect(invitationRepository.save).not.toHaveBeenCalled();
     });
   });

--- a/apps/invitation-service/src/modules/invitations/infrastructure/adapters/project-service.adapter.ts
+++ b/apps/invitation-service/src/modules/invitations/infrastructure/adapters/project-service.adapter.ts
@@ -5,6 +5,7 @@ import {
   ProjectsServiceClient,
   Project,
   AddParticipantResponse,
+  PendingProjectParticipant,
   PROJECTS_SERVICE_NAME
 } from '@app/common/generated/project';
 import { ProjectServicePort } from '../ports/project-service.port';
@@ -36,5 +37,15 @@ export class ProjectServiceAdapter implements ProjectServicePort, OnModuleInit {
     studentCode: string;
   }): Promise<AddParticipantResponse> {
     return await firstValueFrom(this.projectService.addParticipant(params));
+  }
+
+  async listPendingParticipants(
+    projectId: number,
+  ): Promise<PendingProjectParticipant[]> {
+    const response = await firstValueFrom(
+      this.projectService.listPendingParticipants({ projectId }),
+    );
+
+    return response.items ?? [];
   }
 }

--- a/apps/invitation-service/src/modules/invitations/infrastructure/ports/project-service.port.ts
+++ b/apps/invitation-service/src/modules/invitations/infrastructure/ports/project-service.port.ts
@@ -1,6 +1,7 @@
 import type {
   Project,
   AddParticipantResponse,
+  PendingProjectParticipant,
 } from '@app/common/generated/project';
 
 export abstract class ProjectServicePort {
@@ -23,4 +24,14 @@ export abstract class ProjectServicePort {
     userId: number;
     studentCode: string;
   }): Promise<AddParticipantResponse>;
+
+  /**
+   * Retrieves the pending participants for a project.
+   *
+   * @param projectId - The project ID
+   * @returns The list of pending participants
+   */
+  abstract listPendingParticipants(
+    projectId: number,
+  ): Promise<PendingProjectParticipant[]>;
 }


### PR DESCRIPTION
This pull request updates the logic for accepting project invitations in the `AcceptInvitationUseCase`, ensuring that the `studentCode` is resolved from the project's pending participants rather than being passed directly. It also adds new tests to cover these scenarios and updates the project service adapter and port to support listing pending participants.

**Project Invitation Acceptance Logic:**
- The `AcceptInvitationUseCase` now fetches the list of pending participants for a project and matches the invitation email to resolve the correct `studentCode`. If no match is found, it throws an `INVALID_ARGUMENT` error.

**Testing Enhancements:**
- The test suite for `AcceptInvitationUseCase` is updated to mock the new project service methods and includes new test cases for successful and failure scenarios when resolving `studentCode` from pending participants. [[1]](diffhunk://#diff-133c50fadf0c461c2de59d854cb8bb7434b80fd371e491b0c7f21238aa30d6ebL59-R70) [[2]](diffhunk://#diff-133c50fadf0c461c2de59d854cb8bb7434b80fd371e491b0c7f21238aa30d6ebL79-R93) [[3]](diffhunk://#diff-133c50fadf0c461c2de59d854cb8bb7434b80fd371e491b0c7f21238aa30d6ebL93-R104) [[4]](diffhunk://#diff-133c50fadf0c461c2de59d854cb8bb7434b80fd371e491b0c7f21238aa30d6ebR138) [[5]](diffhunk://#diff-133c50fadf0c461c2de59d854cb8bb7434b80fd371e491b0c7f21238aa30d6ebR223-R230) [[6]](diffhunk://#diff-133c50fadf0c461c2de59d854cb8bb7434b80fd371e491b0c7f21238aa30d6ebL424-R501) [[7]](diffhunk://#diff-133c50fadf0c461c2de59d854cb8bb7434b80fd371e491b0c7f21238aa30d6ebR522-R541)

**Project Service Adapter and Port Updates:**
- The `ProjectServiceAdapter` and `ProjectServicePort` are extended with a `listPendingParticipants` method to retrieve pending participants for a project. [[1]](diffhunk://#diff-974020fffe57c40c13f20bb0d2f09e85764a7a9a94de55b1134ebfaa5f853786R8) [[2]](diffhunk://#diff-974020fffe57c40c13f20bb0d2f09e85764a7a9a94de55b1134ebfaa5f853786R41-R50) [[3]](diffhunk://#diff-ed967d959969d69ffbc0d71d0609020a6d089e7fb94326d35f708c876eb46157R4) [[4]](diffhunk://#diff-ed967d959969d69ffbc0d71d0609020a6d089e7fb94326d35f708c876eb46157R27-R36)