### PR TITLE
[CU-86e1k02e6]: Backes-Fix-Azure-emails

### DIFF
--- a/apps/notification-service/src/infrastructure/email/azure.adapter.ts
+++ b/apps/notification-service/src/infrastructure/email/azure.adapter.ts
@@ -118,11 +118,11 @@ export class AzureAdapter implements EmailServicePort, OnModuleInit {
         abortSignal: AbortSignal.timeout(15_000) // 15 segundos máximo
       });
       this.logger.log('Email send initiated, waiting for completion...', { to, subject: compiledSubject });
-      const result = await poller.pollUntilDone({
-        abortSignal: AbortSignal.timeout(30_000) // 30 segundos máximo
-      });
+      //const result = await poller.pollUntilDone({
+       // abortSignal: AbortSignal.timeout(30_000) // 30 segundos máximo
+      //});
 
-      this.logger.log(`Email sent successfully. MessageId: ${result.id}`);
+      //this.logger.log(`Email sent successfully. MessageId: ${poller.id}`);
       return { success: true };
     } catch (error) {
         if ((error as any)?.statusCode === 429) {


### PR DESCRIPTION
This pull request makes a small change to the `AzureAdapter` email service implementation. The code that waits for an email to be fully sent and logs its completion has been commented out, so the method now returns success immediately after initiating the send operation.